### PR TITLE
Replace codes-iso-3166 and codes-iso-4217 with Strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2021"
 
 [dependencies]
 async-stream = "0.3.3"
-codes-iso-3166 = "0.1.3"
-codes-iso-4217 = "0.1.5"
 futures-core = "0.3.25"
 futures-util = "0.3.25"
 once_cell = "1.16.0"
@@ -30,6 +28,8 @@ tokio = { version = "1.23.0" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
+codes-iso-3166 = "0.1.3"
+codes-iso-4217 = "0.1.5"
 futures = "0.3.25"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { version = "1.23.0", features = ["macros"] }

--- a/src/client/customers.rs
+++ b/src/client/customers.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use codes_iso_4217::CurrencyCode;
 use futures_core::Stream;
 use futures_util::stream::TryStreamExt;
 use reqwest::{Method, RequestBuilder};
@@ -84,7 +83,7 @@ pub struct CreateCustomerRequest<'a> {
     pub billing_address: Option<AddressRequest<'a>>,
     /// The currency used for the customer's invoices and balance.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency: Option<CurrencyCode>,
+    pub currency: Option<String>,
     /// The tax ID details to display on the customer's invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_id: Option<TaxIdRequest<'a>>,
@@ -172,7 +171,7 @@ pub struct Customer {
     /// The customer's billing address.
     pub billing_address: Option<Address>,
     /// The currency used for the customer's invoices and balance.
-    pub currency: Option<CurrencyCode>,
+    pub currency: Option<String>,
     /// The tax ID details to display on the customer's invoice.
     pub tax_id: Option<TaxId>,
     /// Undocumented upstream.

--- a/src/client/taxes.rs
+++ b/src/client/taxes.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use codes_iso_3166::part_1::CountryCode;
 use serde::{Deserialize, Serialize};
 use serde_enum_str::{Deserialize_enum_str, Serialize_enum_str};
 
@@ -26,7 +25,7 @@ pub struct TaxIdRequest<'a> {
     /// The value of the tax ID.
     pub value: &'a str,
     /// The country of the tax ID.
-    pub country: CountryCode,
+    pub country: String,
 }
 
 /// Tax ID details to display on an invoice.
@@ -38,7 +37,7 @@ pub struct TaxId {
     /// The value of the tax ID.
     pub value: String,
     /// The country of the tax ID.
-    pub country: CountryCode,
+    pub country: String,
 }
 
 /// The type of a [`TaxId`].

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -305,7 +305,7 @@ async fn test_customers() {
             tax_id: Some(TaxIdRequest {
                 type_: orb_billing::TaxIdType::UsEin,
                 value: "12-3456789",
-                country: CountryCode::US,
+                country: CountryCode::US.to_string(),
             }),
             ..Default::default()
         })
@@ -338,7 +338,7 @@ async fn test_customers() {
         Some(TaxId {
             type_: orb_billing::TaxIdType::UsEin,
             value: "12-3456789".into(),
-            country: CountryCode::US,
+            country: CountryCode::US.to_string(),
         })
     );
 


### PR DESCRIPTION
In line with #40, but this time the goal is to get rid of these dependencies that are somewhat heavy (they pull in a whole bunch of HTML parsing crates into the dependency tree)