### PR TITLE
update pagination limit in comment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -85,7 +85,7 @@ impl ListParams {
     /// The page size only affects the size of each HTTP response. It does not
     /// change the observable output of the API.
     ///
-    /// The default page size is 20. The maximum page size is 500.
+    /// The default page size is 20. The maximum page size is 100.
     ///
     /// See the [Orb API pagination documentation][orb-docs] for details.
     ///


### PR DESCRIPTION
part of https://linear.app/convex/issue/ENG-8346

All our list API endpoints just use the default of 20 right now but updating the comment.