### PR TITLE
Accept stringified numbers for remaining numeric response fields

### DIFF
--- a/src/client/alerts.rs
+++ b/src/client/alerts.rs
@@ -99,6 +99,7 @@ pub enum AlertType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct AlertThreshold {
     /// The threshold value
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub value: serde_json::Number,
 }
 

--- a/src/client/coupons.rs
+++ b/src/client/coupons.rs
@@ -17,12 +17,21 @@ pub struct Coupon {
     /// User-facing coupon code
     pub redemption_code: String,
     /// The number of times this coupon has been redeemed.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub times_redeemed: serde_json::Number,
     /// This allows for a coupon's discount to apply for a limited time
     /// (determined in months); a null value here means "unlimited time".
+    #[serde(
+        default,
+        deserialize_with = "serde_aux::field_attributes::deserialize_option_number_from_string"
+    )]
     pub duration_in_months: Option<serde_json::Number>,
     /// The maximum number of redemptions allowed for this coupon before it is exhausted;
     /// null here means "unlimited".
+    #[serde(
+        default,
+        deserialize_with = "serde_aux::field_attributes::deserialize_option_number_from_string"
+    )]
     pub max_redemptions: Option<serde_json::Number>,
     /// The type of discount
     pub discount: Discount,
@@ -41,6 +50,7 @@ pub enum Discount {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct PercentageDiscount {
     pub applies_to_price_ids: Vec<String>,
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub percentage_discount: serde_json::Number,
 }
 
@@ -121,5 +131,19 @@ impl Client {
             None => req,
         };
         self.stream_paginated_request(&params.inner, req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentage_discount_accepts_stringified_number() {
+        let disc: PercentageDiscount = serde_json::from_value(serde_json::json!({
+            "applies_to_price_ids": ["p_1"],
+            "percentage_discount": "0.25"
+        })).unwrap();
+        assert_eq!(disc.percentage_discount.as_f64().unwrap(), 0.25);
     }
 }

--- a/src/client/customers.rs
+++ b/src/client/customers.rs
@@ -363,6 +363,7 @@ pub struct CustomerCreditBlock {
     /// The Orb-assigned unique identifier for the credit block.
     pub id: String,
     /// The remaining credit balance for the block.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub balance: serde_json::Number,
     /// The date on which the block's balance will expire.
     #[serde(default, with = "time::serde::rfc3339::option")]
@@ -426,16 +427,20 @@ pub struct BaseLedgerEntry {
     /// The Orb-assigned unique identifier for the ledger entry.
     pub id: String,
     /// An incrementing identifier ordering the ledger entry relative to others.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub ledger_sequence_number: u64,
     /// The state of the ledger entry.
     pub entry_status: EntryStatus,
     /// The customer identifiers associated with the ledger entry.
     pub customer: CustomerIdentifier,
     /// The customer's credit balance before application of the ledger operation.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub starting_balance: serde_json::Number,
     /// The customer's credit balance after application of the ledger operation.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub ending_balance: serde_json::Number,
     /// The amount granted to the ledger.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub amount: serde_json::Number,
     /// The date the ledger entry was created.
     #[serde(with = "time::serde::rfc3339")]
@@ -463,6 +468,7 @@ pub struct VoidLedgerEntry {
     /// The reason the ledger entry was voided.
     pub void_reason: Option<String>,
     /// The amount voided from the ledger.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub void_amount: serde_json::Number,
 }
 
@@ -478,6 +484,7 @@ pub struct VoidInitiatedLedgerEntry {
     /// The reason the ledger entry was voided.
     pub void_reason: Option<String>,
     /// The amount voided from the ledger.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub void_amount: serde_json::Number,
 }
 
@@ -592,6 +599,10 @@ pub struct CustomerCostBucket {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CustomerCostPriceBlock {
     /// The price's quantity for the timeframe.
+    #[serde(
+        default,
+        deserialize_with = "serde_aux::field_attributes::deserialize_option_number_from_string"
+    )]
     pub quantity: Option<serde_json::Number>,
     /// The price's contributions for the timeframe, excluding any minimums and discounts.
     pub subtotal: String,

--- a/src/client/invoices.rs
+++ b/src/client/invoices.rs
@@ -138,6 +138,7 @@ pub struct InvoiceLineItem {
     /// The name of the price associated with this line item.
     pub name: String,
     /// Either the fixed fee quantity or the usage during the service period.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub quantity: serde_json::Number,
     /// The start date of the range of time applied for this line item's price.
     #[serde(with = "time::serde::rfc3339")]
@@ -196,6 +197,7 @@ pub enum InvoiceSubLineItem {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct TieredSubLineItem {
     pub amount: String,
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub quantity: serde_json::Number,
     pub tier_config: Tier,
 }
@@ -208,6 +210,10 @@ pub struct AutoCollection {
     #[serde(default, with = "time::serde::rfc3339::option")]
     pub previously_attempted_at: Option<OffsetDateTime>,
     pub enabled: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "serde_aux::field_attributes::deserialize_option_number_from_string"
+    )]
     pub num_attempts: Option<u64>,
 }
 

--- a/src/client/subscriptions.rs
+++ b/src/client/subscriptions.rs
@@ -307,6 +307,7 @@ pub struct SubscriptionUsageEntry {
     #[serde(with = "time::serde::rfc3339")]
     pub timeframe_end: OffsetDateTime,
     /// The quantity of usage for the timeframe.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub quantity: serde_json::Number,
 }
 
@@ -337,6 +338,10 @@ pub struct Subscription<C = Customer> {
     pub current_billing_period_end_date: Option<OffsetDateTime>,
     /// The current plan phase that is active, if the subscription's plan has
     /// phases.
+    #[serde(
+        default,
+        deserialize_with = "serde_aux::field_attributes::deserialize_option_number_from_string"
+    )]
     pub active_plan_phase_order: Option<i64>,
     /// List of all fixed fee quantities associated with this subscription.
     pub fixed_fee_quantity_schedule: Vec<SubscriptionFixedFee>,
@@ -345,6 +350,7 @@ pub struct Subscription<C = Customer> {
     ///
     /// A value of zero indicates that the invoice is due on issue, whereas a
     /// value of 30 represents that the customer has a month to pay the invoice.
+    #[serde(deserialize_with = "serde_aux::field_attributes::deserialize_number_from_string")]
     pub net_terms: i64,
     /// Determines whether issued invoices for this subscription will
     /// automatically be charged with the saved payment method on the due date.


### PR DESCRIPTION
## Summary

- Fixes Databricks dump failure on `PercentageDiscount.percentage_discount` when the value arrives as a JSON string (e.g. `"1"`) instead of a number.
- Sweeps the same `serde_aux` pattern from #69/#70/#71 across the rest of the crate's Deserialize-able numeric fields so future paper cuts don't keep recurring.
- Touched types: `Coupon`, `PercentageDiscount`, `CustomerCreditBlock`, `BaseLedgerEntry`, `VoidLedgerEntry`, `VoidInitiatedLedgerEntry`, `CustomerCostPriceBlock`, `InvoiceLineItem`, `TieredSubLineItem`, `AutoCollection`, `AlertThreshold`, `SubscriptionUsageEntry`, `Subscription`. Request-only `Serialize` types were intentionally left alone.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 4/4 pass, including new `percentage_discount_accepts_stringified_number`

🤖 Generated with [Claude Code](https://claude.com/claude-code)