### PR TITLE
Add Matrix price variant and per-price cost exports

### DIFF
--- a/src/client/prices.rs
+++ b/src/client/prices.rs
@@ -19,7 +19,51 @@ pub enum Price {
     /// Used to represent tiered prices
     #[serde(rename = "tiered")]
     Tiered(TieredPrice),
+    /// Used to represent matrix (dimensional) prices, e.g. a rate that varies by
+    /// region or deployment class.
+    #[serde(rename = "matrix")]
+    Matrix(MatrixPrice),
     // TODO: Add support for additional prices
+}
+
+/// In matrix pricing, the per-unit rate is looked up in a one- or two-dimensional
+/// matrix keyed by dimension values (e.g. region, deployment class).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct MatrixPrice {
+    /// Id of the price
+    pub id: String,
+    /// Name of the price
+    pub name: String,
+    /// Config with rates per matrix cell
+    pub matrix_config: MatrixConfig,
+    /// Which phase of the plan this price is associated with
+    #[serde(
+        default,
+        deserialize_with = "serde_aux::field_attributes::deserialize_option_number_from_string"
+    )]
+    pub plan_phase_order: Option<i64>,
+    /// Non-null when this price represents a credit allocation (pre-pay).
+    pub credit_allocation: Option<CreditAllocation>,
+}
+
+/// Configuration for a matrix (dimensional) price.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct MatrixConfig {
+    /// The fallback per-unit amount when no matrix cell matches.
+    pub default_unit_amount: String,
+    /// The dimensions modeled by the matrix, e.g. `["region"]`.
+    pub dimensions: Vec<Option<String>>,
+    /// The per-unit amount for each configured matrix cell.
+    pub matrix_values: Vec<MatrixValue>,
+}
+
+/// A per-unit amount for a single cell of a matrix price.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct MatrixValue {
+    /// The dimension values identifying this cell.
+    pub dimension_values: Vec<Option<String>>,
+    /// The per-unit amount usage in this cell bills at.
+    pub unit_amount: String,
 }
 
 /// With unit pricing, each unit costs a fixed amount.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,12 +66,12 @@ pub use client::invoices::{
 };
 pub use client::marketplaces::ExternalMarketplace;
 pub use client::plans::{Plan, PlanId, PlanListParams};
-pub use client::prices::{AddAdjustmentInterval, AddPriceInterval, Adjustment, CreditAllocation, EditAdjustmentInterval, EditPriceInterval, FixedFeeQuantityTransition, NewAdjustment, NewMaximumAdjustment, 
-    OverrideUnitPrice, Price, PriceType, PriceInterval, PriceOverride, QuantityOnlyPriceOverride, SubscriptionAdjustmentInterval, TieredPrice, 
+pub use client::prices::{AddAdjustmentInterval, AddPriceInterval, Adjustment, CreditAllocation, EditAdjustmentInterval, EditPriceInterval, FixedFeeQuantityTransition, MatrixConfig, MatrixPrice, MatrixValue, NewAdjustment, NewMaximumAdjustment,
+    OverrideUnitPrice, Price, PriceType, PriceInterval, PriceOverride, QuantityOnlyPriceOverride, SubscriptionAdjustmentInterval, TieredPrice,
     TransformPriceFilter, TransformPriceFilterField, TransformPriceFilterOperator, UnitPrice};
 pub use client::subscriptions::{
     BillingCycleAlignment, ChangeOption, CancelSubscriptionRequest, CreateSubscriptionRequest, PriceIntervalsRequest, SchedulePlanChangeRequest, Subscription, SubscriptionListParams,
-    SubscriptionStatus, UpdatePriceQuantityRequest, UpdateSubscriptionRequest, FetchSubscriptionCostsRequest, FetchSubscriptionCostsResponse, SubscriptionCostsEntry,
+    SubscriptionStatus, UpdatePriceQuantityRequest, UpdateSubscriptionRequest, FetchSubscriptionCostsRequest, FetchSubscriptionCostsResponse, PerPriceCostsEntry, SubscriptionCostsEntry,
     FetchSubscriptionUsageRequest, FetchSubscriptionUsageResponse
 };
 pub use client::taxes::{TaxId, TaxIdRequest, TaxIdType};


### PR DESCRIPTION
## What

Adds support for **matrix (dimensional) prices** to the Orb client and exports a previously-defined-but-unexported cost type.

### `src/client/prices.rs`
- Adds a `Matrix(MatrixPrice)` variant to the `Price` enum, tagged `#[serde(rename = "matrix")]`.
- Adds `MatrixPrice` / `MatrixConfig` / `MatrixValue` structs, mirroring the existing `UnitPrice` / `TieredPrice` style.

This is the actual fix: without a matrix arm, the `#[serde(tag = "model_type")]` enum throws on any dimensional price, so `fetch_subscription_costs` would error.

### `src/lib.rs`
- Re-exports `MatrixConfig`, `MatrixPrice`, `MatrixValue`, and `PerPriceCostsEntry` (the last was defined but not exported, which is why callers couldn't read per-price subscription costs).

No exhaustive matches inside the fork itself break — the fork has no exhaustive matches on `Price`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)